### PR TITLE
add circular/linear binning paths

### DIFF
--- a/HiFi-MAG-Pipeline/Snakefile-hifimags
+++ b/HiFi-MAG-Pipeline/Snakefile-hifimags
@@ -1,5 +1,6 @@
-
-localrules: BamDepth, SummarizeCheckM, PlotCheckM, PrepBatchFile, SummarizeResults, SummaryPlots, all
+localrules: 
+    ParseContigs, BamDepth, WriteCircularBins, MakeLinCircDASinput, MakeFullDASinput,
+    SummarizeCheckM, PlotCheckM, PrepBatchFile, SummarizeResults, SummaryPlots, all
 
 configfile: "config.yaml"
 
@@ -7,18 +8,19 @@ SAMPLES = config['samplenames']
 
 rule all:
     input:
-        expand("5-gtdb-individual/{sample}/{dir}/", sample = SAMPLES, dir = ["align", "classify", "identify"]),
-        expand("6-summary/{sample}/{sample}-binplots/{sample}-{filt}-compl-vs-{type}.pdf", sample = SAMPLES, filt = ["unfiltered", "filtered"], type = ["contam", "contam-contigNums", "contam-Bins"]),
-        expand("6-summary/{sample}/{sample}.HiFi-MAG.summary.txt", sample = SAMPLES),
-        expand("6-summary/{sample}/{sample}.Completeness-Contamination-Contigs.pdf", sample = SAMPLES),
-        expand("6-summary/{sample}/{sample}.GenomeSizes-Depths.pdf", sample = SAMPLES)
+        expand("7-gtdb-individual/{sample}/{dir}/", sample = SAMPLES, dir = ["align", "classify", "identify"]),
+        expand("8-summary/{sample}/{sample}-binplots/{sample}-{filt}-compl-vs-{type}.pdf", sample = SAMPLES, filt = ["unfiltered", "filtered"], type = ["contam", "contam-contigNums", "contam-Bins"]),
+        expand("8-summary/{sample}/{sample}.HiFi-MAG.summary.txt", sample = SAMPLES),
+        expand("8-summary/{sample}/{sample}.Completeness-Contamination-Contigs.pdf", sample = SAMPLES),
+        expand("8-summary/{sample}/{sample}.GenomeSizes-Depths.pdf", sample = SAMPLES)
 
+        
 rule MinimapToBam:
     input:
         reads = "inputs/{sample}.fasta",
         contigs = "inputs/{sample}.contigs.fasta"
     output:
-        "1-bam/{sample}.bam"
+        "2-bam/{sample}.bam"
     conda:
         "envs/samtools.yml"
     threads: 
@@ -31,12 +33,33 @@ rule MinimapToBam:
         "minimap2 -a -k 19 -w 10 -I 10G -g 5000 -r 2000 --lj-min-ratio 0.5 "
         "-A 2 -B 5 -O 5,56 -E 4,1 -z 400,50 --sam-hit-only -t {threads} " 
         "{input.contigs} {input.reads} 2> {log} | samtools sort -@ {threads} -o {output}"
-        
+
+rule ParseContigs:
+    input:
+        contigs = "inputs/{sample}.contigs.fasta"
+    output:
+        fastacircular = "1-contigs/{sample}.circular.fasta",
+        fastalinear = "1-contigs/{sample}.linear.fasta",
+        logcircular = "1-contigs/{sample}.circular.txt",
+        loglinear = "1-contigs/{sample}.linear.txt"
+    conda:
+        "envs/python.yml"
+    params: 
+        assembler = config['assembler']
+    log: 
+        "logs/{sample}.ParseContigs.log"
+    benchmark: 
+        "benchmarks/{sample}.ParseContigs.tsv"
+    shell:
+        "python scripts/Filter-CircLin-Contigs.py -f {input.contigs} -a {params.assembler} "
+        "-o1 {output.fastalinear} -o2 {output.fastacircular} -o3 {output.loglinear} -o4 {output.logcircular} "
+        "--metaflye_info inputs/{wildcards.sample}-assembly_info.txt &> {log}"
+     
 rule BamDepth:
     input:
-        bam = "1-bam/{sample}.bam"
+        bam = "2-bam/{sample}.bam"
     output:
-        "1-bam/{sample}.depth.txt"
+        "2-bam/{sample}.depth.txt"
     conda:
         "envs/metabat.yml"
     log:
@@ -46,40 +69,134 @@ rule BamDepth:
     shell:
         "jgi_summarize_bam_contig_depths --outputDepth {output} {input.bam} 2> {log}"
 
-rule RunMetabat:
+rule RunMetabatLinear:
     input:
-        contigs = "inputs/{sample}.contigs.fasta",
-        depths = "1-bam/{sample}.depth.txt"
+        contigs = "1-contigs/{sample}.linear.fasta",
+        depths = "2-bam/{sample}.depth.txt"
     output:
-        file = "2-metabat-bins/{sample}.completed.txt",
-        outdir = directory("2-metabat-bins/{sample}/")
+        complete = "3-metabat-bins-linear-circ/{sample}.linear-completed.txt",
+        outdir = directory("3-metabat-bins-linear-circ/{sample}/")
     conda:
         "envs/metabat.yml"
     threads: 
         config['metabat']['threads']
     params:
-        prefix = "2-metabat-bins/{sample}/{sample}_bin"
+        prefix = "3-metabat-bins-linear-circ/{sample}/{sample}_bin.lin"
     log: 
-        "logs/{sample}.RunMetabat.log"
+        "logs/{sample}.RunMetabatLinear.log"
     benchmark: 
-        "benchmarks/{sample}.RunMetabat.tsv"
+        "benchmarks/{sample}.RunMetabatLinear.tsv"
     shell:
         "metabat2 -i {input.contigs} -a {input.depths} -o {params.prefix} -t {threads} "
-        "-v &> {log} && touch {output.file}"
-        
+        "-v &> {log} && touch {output.complete}"
+
+rule WriteCircularBins:
+    input:
+        fastacircular = "1-contigs/{sample}.circular.fasta",
+        file = "3-metabat-bins-linear-circ/{sample}.linear-completed.txt",
+        outdir = "3-metabat-bins-linear-circ/{sample}/"
+    output:
+        "3-metabat-bins-linear-circ/{sample}.circular-completed.txt"
+    conda:
+        "envs/python.yml"
+    threads: 
+        config['metabat']['threads']
+    log: 
+        "logs/{sample}.WriteCircularBins.log"
+    benchmark: 
+        "benchmarks/{sample}.WriteCircularBins.tsv"
+    shell:
+        "python scripts/Copy-Circ-Contigs.py -f {input.fastacircular} -s {wildcards.sample} "
+        "-o1 {input.outdir} -o2 {output} &> {log}"
+
+rule RunMetabatFull:
+    input:
+        contigs = "inputs/{sample}.contigs.fasta",
+        depths = "2-bam/{sample}.depth.txt"
+    output:
+        complete = "3-metabat-bins-full/{sample}.full-completed.txt",
+        outdir = directory("3-metabat-bins-full/{sample}/")
+    conda:
+        "envs/metabat.yml"
+    threads: 
+        config['metabat']['threads']
+    params:
+        prefix = "3-metabat-bins-full/{sample}/{sample}_bin.full"
+    log: 
+        "logs/{sample}.RunMetabatFull.log"
+    benchmark: 
+        "benchmarks/{sample}.RunMetabatFull.tsv"
+    shell:
+        "metabat2 -i {input.contigs} -a {input.depths} -o {params.prefix} -t {threads} "
+        "-v &> {log} && touch {output.complete}"
+
+rule MakeLinCircDASinput:
+    input:
+        complete_lin = "3-metabat-bins-linear-circ/{sample}.linear-completed.txt",
+        complete_circ = "3-metabat-bins-linear-circ/{sample}.circular-completed.txt",
+        indir = "3-metabat-bins-linear-circ/{sample}/"
+    output:
+        "4-DAStool/{sample}.linear-circ.tsv"
+    conda:
+        "envs/dastool.yml"
+    log: 
+        "logs/{sample}.MakeLinCircDASinput.log"
+    benchmark: 
+        "benchmarks/{sample}.MakeLinCircDASinput.tsv"
+    shell:
+        "Fasta_to_Scaffolds2Bin.sh -i {input.indir} -e fa 1> {output} 2> {log}"
+
+rule MakeFullDASinput:
+    input:
+        "3-metabat-bins-full/{sample}/"
+    output:
+        "4-DAStool/{sample}.full.tsv"
+    conda:
+        "envs/dastool.yml"
+    log: 
+        "logs/{sample}.MakeFullDASinput.log"
+    benchmark: 
+        "benchmarks/{sample}.MakeFullDASinput.tsv"
+    shell:
+        "Fasta_to_Scaffolds2Bin.sh -i {input} -e fa 1> {output} 2> {log}"
+
+rule RunDAStool:
+    input:
+        full = "4-DAStool/{sample}.full.tsv",
+        lincirc = "4-DAStool/{sample}.linear-circ.tsv",
+        contigs = "inputs/{sample}.contigs.fasta"
+    output:
+        binsdir = directory("4-DAStool/{sample}_DASTool_bins/"),
+        complete = "4-DAStool/{sample}.complete.txt"
+    conda:
+        "envs/dastool.yml"
+    threads: 
+        config['dastool']['threads']
+    params:
+        outlabel = "4-DAStool/{sample}",
+        search = config['dastool']['search']
+    log: 
+        "logs/{sample}.RunDAStool.log"
+    benchmark: 
+        "benchmarks/{sample}.RunDAStool.tsv"
+    shell:
+        "DAS_Tool -i {input.lincirc},{input.full} -c {input.contigs} -l lincirc,full "
+        "-o {params.outlabel} --search_engine {params.search} --write_bins 1 -t {threads} "
+        "&> {log} && touch {output.complete}"
+
 rule RunCheckM:
     input:
-        metaoutput = "2-metabat-bins/{sample}.completed.txt"
+        complete = "4-DAStool/{sample}.complete.txt",
+        indir = "4-DAStool/{sample}_DASTool_bins/"
     output:
-        "3-checkm/{sample}/lineage.ms"
+        "5-checkm/{sample}/lineage.ms"
     conda:
         "envs/checkm.yml"
     threads: 
         config['checkm']['threads']
     params:
         ppthreads = config['checkm']['pplacer_threads'],
-        indir = "2-metabat-bins/{sample}/",
-        outdir = "3-checkm/{sample}/",
+        outdir = "5-checkm/{sample}/",
         datapath = config['checkm']['datapath'],
         tmpdir = config['tmpdir']
     log: 
@@ -89,18 +206,18 @@ rule RunCheckM:
         "benchmarks/{sample}.RunCheckM.tsv"
     shell:
         "checkm data setRoot {params.datapath} &> {log.root} && checkm lineage_wf -x fa -t {threads} "
-        "--pplacer_threads {params.ppthreads} --tmpdir {params.tmpdir} {params.indir} "
+        "--pplacer_threads {params.ppthreads} --tmpdir {params.tmpdir} {input.indir} "
         "{params.outdir} &> {log.run}"
-        
+         
 rule SummarizeCheckM:
     input:
-        "3-checkm/{sample}/lineage.ms"
+        "5-checkm/{sample}/lineage.ms"
     output:
-        "4-checkm-summary/CheckM.{sample}.qa.txt"
+        "6-checkm-summary/CheckM.{sample}.qa.txt"
     conda:
         "envs/checkm.yml"
     params:
-        outdir = "3-checkm/{sample}/"
+        outdir = "5-checkm/{sample}/"
     log: 
         "logs/{sample}.SummarizeCheckM.log"
     benchmark: 
@@ -110,11 +227,11 @@ rule SummarizeCheckM:
 
 rule PrepBatchFile:
     input:
-        sumfile = "4-checkm-summary/CheckM.{sample}.qa.txt",
-        indir = "2-metabat-bins/{sample}/"
+        sumfile = "6-checkm-summary/CheckM.{sample}.qa.txt",
+        indir = "4-DAStool/{sample}_DASTool_bins/"
     output:
-        batch = "4-checkm-summary/{sample}.batchfile.txt",
-        simple = "4-checkm-summary/CheckM.{sample}.simple.txt"
+        batch = "6-checkm-summary/{sample}.batchfile.txt",
+        simple = "6-checkm-summary/CheckM.{sample}.simple.txt"
     conda:
         "envs/python.yml"
     params:
@@ -132,11 +249,11 @@ rule PrepBatchFile:
 
 rule RunGTDBTkIndividual:
     input:
-        "4-checkm-summary/{sample}.batchfile.txt"
+        "6-checkm-summary/{sample}.batchfile.txt"
     output:
-        directory("5-gtdb-individual/{sample}/align/"),
-        directory("5-gtdb-individual/{sample}/classify/"),
-        directory("5-gtdb-individual/{sample}/identify/"),
+        directory("7-gtdb-individual/{sample}/align/"),
+        directory("7-gtdb-individual/{sample}/classify/"),
+        directory("7-gtdb-individual/{sample}/identify/"),
     conda:
         "envs/gtdbtk.yml"
     threads: 
@@ -144,7 +261,7 @@ rule RunGTDBTkIndividual:
     params:
         ppthreads = config['gtdbtk']['pplacer_threads'],
         gtdbtk_data = config['gtdbtk']['gtdbtk_data'],
-        outdir = "5-gtdb-individual/{sample}/",
+        outdir = "7-gtdb-individual/{sample}/",
         tmpdir = config['tmpdir']
     log: 
         "logs/{sample}.RunGTDBTkIndividual.log"
@@ -157,14 +274,14 @@ rule RunGTDBTkIndividual:
         
 rule PlotCheckM:
     input:
-        "4-checkm-summary/CheckM.{sample}.qa.txt"
+        "6-checkm-summary/CheckM.{sample}.qa.txt"
     output:
-        o1 = "6-summary/{sample}/{sample}-binplots/{sample}-unfiltered-compl-vs-contam.pdf",
-        o2 = "6-summary/{sample}/{sample}-binplots/{sample}-unfiltered-compl-vs-contam-contigNums.pdf",
-        o3 = "6-summary/{sample}/{sample}-binplots/{sample}-unfiltered-compl-vs-contam-Bins.pdf",
-        o4 = "6-summary/{sample}/{sample}-binplots/{sample}-filtered-compl-vs-contam.pdf",
-        o5 = "6-summary/{sample}/{sample}-binplots/{sample}-filtered-compl-vs-contam-contigNums.pdf",
-        o6 = "6-summary/{sample}/{sample}-binplots/{sample}-filtered-compl-vs-contam-Bins.pdf"
+        o1 = "8-summary/{sample}/{sample}-binplots/{sample}-unfiltered-compl-vs-contam.pdf",
+        o2 = "8-summary/{sample}/{sample}-binplots/{sample}-unfiltered-compl-vs-contam-contigNums.pdf",
+        o3 = "8-summary/{sample}/{sample}-binplots/{sample}-unfiltered-compl-vs-contam-Bins.pdf",
+        o4 = "8-summary/{sample}/{sample}-binplots/{sample}-filtered-compl-vs-contam.pdf",
+        o5 = "8-summary/{sample}/{sample}-binplots/{sample}-filtered-compl-vs-contam-contigNums.pdf",
+        o6 = "8-summary/{sample}/{sample}-binplots/{sample}-filtered-compl-vs-contam-Bins.pdf"
     conda:
         "envs/python.yml"
     params:
@@ -182,32 +299,34 @@ rule PlotCheckM:
         
 rule SummarizeResults:
     input:
-        depth = "1-bam/{sample}.depth.txt",
-        batch = "4-checkm-summary/{sample}.batchfile.txt",
-        checkm = "4-checkm-summary/CheckM.{sample}.simple.txt",
-        gtdbdir = "5-gtdb-individual/{sample}/classify/"
+        depth = "2-bam/{sample}.depth.txt",
+        batch = "6-checkm-summary/{sample}.batchfile.txt",
+        checkm = "6-checkm-summary/CheckM.{sample}.simple.txt",
+        gtdbdir = "7-gtdb-individual/{sample}/classify/",
+        plot = "8-summary/{sample}/{sample}-binplots/{sample}-unfiltered-compl-vs-contam.pdf"
     output:
-        outfile = "6-summary/{sample}/{sample}.HiFi-MAG.summary.txt"
+        outfile = "8-summary/{sample}/{sample}.HiFi-MAG.summary.txt"
     conda:
         "envs/python.yml"
     params:
         gtdbtk_data = config['gtdbtk']['gtdbtk_data'],
-        outdir = "6-summary/{sample}/{sample}-bin-ref-pairs/"
+        outdir1 = "8-summary/{sample}/{sample}-bin-ref-pairs/",
+        outdir2 = "8-summary/{sample}/{sample}-bins/"
     log: 
         "logs/{sample}.SummarizeResults.log"
     benchmark: 
         "benchmarks/{sample}.SummarizeResults.tsv"
     shell:
-        "python scripts/genome-binning-summarizer.py -d {input.depth} -b {input.batch} "
-        "-c {input.checkm} -g {input.gtdbdir} -j {params.gtdbtk_data} -o {output.outfile} "
-        "-s {params.outdir} -l {log}"
+        "python scripts/genome-binning-summarizer.py -d {input.depth} "
+        "-b {input.batch} -c {input.checkm} -g {input.gtdbdir} -j {params.gtdbtk_data} "
+        "-o {output.outfile} -o1 {params.outdir1} -o2 {params.outdir2} -l {log}"
 
 rule SummaryPlots:
     input:
-        "6-summary/{sample}/{sample}.HiFi-MAG.summary.txt"
+        "8-summary/{sample}/{sample}.HiFi-MAG.summary.txt"
     output:
-        o1 = "6-summary/{sample}/{sample}.Completeness-Contamination-Contigs.pdf",
-        o2 = "6-summary/{sample}/{sample}.GenomeSizes-Depths.pdf"
+        o1 = "8-summary/{sample}/{sample}.Completeness-Contamination-Contigs.pdf",
+        o2 = "8-summary/{sample}/{sample}.GenomeSizes-Depths.pdf"
     conda:
         "envs/python.yml"
     log: 

--- a/HiFi-MAG-Pipeline/config.yaml
+++ b/HiFi-MAG-Pipeline/config.yaml
@@ -1,3 +1,18 @@
+
+# Choose the assembler used to generate the contigs. Choices currently include:
+# hicanu 
+# hifiasm-meta
+# metaflye
+
+# If you select metaflye, you must also provide the SAMPLE-assembly_info.txt file
+# for each sample in the inputs/ folder. 
+
+# The choice of assembler changes how the script will look for circular contigs in the 
+# contigs fasta files. This step is important in separating the circular and linear contigs 
+# into different files, as binning is only performing for the linear contigs.
+assembler: "hifiasm-meta"
+
+
 # The path to use as the temporary directory to write large files to, which is used with the
 # --tmpdir flag in checkm, and the --scratch_dir flag in gtdb. If using HPC, use "/scratch" 
 # if you have access. If you do not have access to "/scratch" on HPC or are running 
@@ -12,9 +27,16 @@ minimap:
 metabat:
   # The number of threads to use for metabat2.
   threads: 12
+
+dastool:
+  # The number of threads to use for DAS Tool.
+  threads: 24
+  # The engine for single copy gene searching, choices include:
+  # blast, diamond, usearch.
+  search: "diamond"
   
 checkm:
-  # The number of threads to use for checkm.
+  # The number of threads to use for CheckM.
   threads: 24
   
   # The number of threads to use for pplacer when it is called within checkm.
@@ -38,7 +60,7 @@ gtdbtk:
   # The maximum number of contigs allowed in a genome bin.
   max_contigs: 10
   
-  # The number of threads to use for gtdbtk.
+  # The number of threads to use for gtdb-tk.
   threads: 32
   
   # The number of threads to use for pplacer when it is called within gtdbtk.

--- a/HiFi-MAG-Pipeline/envs/dastool.yml
+++ b/HiFi-MAG-Pipeline/envs/dastool.yml
@@ -1,0 +1,7 @@
+name: dastool_env
+channels:
+- bioconda
+- conda-forge
+dependencies:
+- das_tool == 1.1.3
+

--- a/HiFi-MAG-Pipeline/envs/python.yml
+++ b/HiFi-MAG-Pipeline/envs/python.yml
@@ -9,4 +9,4 @@ dependencies:
 - pandas
 - seaborn
 - matplotlib
-- biopython
+- biopython == 1.77

--- a/HiFi-MAG-Pipeline/scripts/CheckM-to-batch-GTDB.py
+++ b/HiFi-MAG-Pipeline/scripts/CheckM-to-batch-GTDB.py
@@ -64,16 +64,16 @@ def parse_summary(infile, completeness, contamination, contigs, binpath, outfile
                     else:
                         print("{} is valid!".format(fpath))
                     fhout.write("{0}\t{1}\n".format(fpath, cols[0]))
-                    passed.append("PASSED\t{}\t{}\t{}\t{}\t{}\t{}\n".format(cols[0], cols[5], cols[6],
-                                                                          cols[7], cols[8], cols[11]))
+                    passed.append("PASSED\t{}\t{}\t{}\t{}\t{}\t{}\t{}\n".format(cols[0], cols[5], cols[6],
+                                                                          cols[7], cols[8], cols[11], cols[18]))
                 else:
-                    failed.append("FAILED\t{}\t{}\t{}\t{}\t{}\t{}\n".format(cols[0], cols[5], cols[6],
-                                                                          cols[7], cols[8], cols[11]))
+                    failed.append("FAILED\t{}\t{}\t{}\t{}\t{}\t{}\t{}\n".format(cols[0], cols[5], cols[6],
+                                                                          cols[7], cols[8], cols[11], cols[18]))
     return passed, failed
 
 def write_log(logfile, passed, failed):
     with open(logfile, 'a') as fh:
-        fh.write("Filter\tBin\tCompleteness\tContamination\tStrainHeterogeneity\tGenomeSize\tContigs\n")
+        fh.write("Filter\tBin\tCompleteness\tContamination\tStrainHeterogeneity\tGenomeSize\tContigs\tGC\n")
         for p in passed:
             fh.write(p)
         for f in failed:

--- a/HiFi-MAG-Pipeline/scripts/Copy-Circ-Contigs.py
+++ b/HiFi-MAG-Pipeline/scripts/Copy-Circ-Contigs.py
@@ -1,0 +1,49 @@
+import argparse
+import os
+import pandas as pd
+from Bio import SeqIO
+
+def get_args():
+    """
+    Get arguments from command line with argparse.
+    """
+    parser = argparse.ArgumentParser(
+        prog='Copy-Circ-Contigs.py',
+        description="""Add circular contigs to bins.""")
+
+    parser.add_argument("-f", "--fasta",
+                        required=True,
+                        help="Full path to the input fasta file.")
+    parser.add_argument("-s", "--sample",
+                        required=True,
+                        help="Name of sample.")
+    parser.add_argument("-o1", "--outdir",
+                        required=True,
+                        help="Name of output fasta file (linear).")
+    parser.add_argument("-o2", "--outfile",
+                        required=True,
+                        help="Name of output fasta file (linear).")
+    return parser.parse_args()
+
+def write_bins(fasta, sample, outdir):
+    """
+    outdir = directory("3-metabat-bins/{sample}/")
+    sample = sample
+    /3-metabat-bins/SAMPLE/SAMPLE_bin.1.fa
+    """
+    bin_count = int(1)
+    for rec in SeqIO.parse(fasta, "fasta"):
+        outname = os.path.join(outdir, "{}_bin.circ{}.fa".format(sample, bin_count))
+        with open(outname, 'a') as fh:
+            fh.write(rec.format("fasta"))
+        bin_count += 1
+
+def main():
+    args = get_args()
+    write_bins(args.fasta, args.sample, args.outdir)
+    with open(args.outfile, 'a') as fh:
+        fh.write("Completed.")
+
+if __name__ == '__main__':
+    main()
+

--- a/HiFi-MAG-Pipeline/scripts/Filter-CircLin-Contigs.py
+++ b/HiFi-MAG-Pipeline/scripts/Filter-CircLin-Contigs.py
@@ -1,0 +1,168 @@
+import argparse
+import os
+import pandas as pd
+from Bio import SeqIO
+
+def get_args():
+    """
+    Get arguments from command line with argparse.
+    """
+    parser = argparse.ArgumentParser(
+        prog='Filter-CircLin-Contigs.py',
+        description="""Separate linear and circular contigs into distinct fasta files.""")
+
+    parser.add_argument("-f", "--fasta",
+                        required=True,
+                        help="Full path to the input fasta file.")
+    parser.add_argument("-a", "--assembler",
+                        required=True,
+                        choices=["hifiasm-meta", "hicanu", "metaflye"],
+                        help="Assembler used.")
+    parser.add_argument("--metaflye_info",
+                        required=False,
+                        help="Name of metaflye asembly info file.")
+    parser.add_argument("-o1", "--fastalinear",
+                        required=True,
+                        help="Name of output fasta file (linear).")
+    parser.add_argument("-o2", "--fastacircular",
+                        required=True,
+                        help="Name of output fasta file (circular).")
+    parser.add_argument("-o3", "--loglinear",
+                        required=True,
+                        help="Name of output fasta file (linear).")
+    parser.add_argument("-o4", "--logcircular",
+                        required=True,
+                        help="Name of output fasta file (circular).")
+
+    return parser.parse_args()
+
+def write_headers(f):
+    with open(f, 'a') as fh:
+        fh.write('Contig\tLength\n')
+
+def parse_hifiasm(fasta, fastalinear, fastacircular, loglinear, logcircular):
+    """
+    hifiasm-meta contig names will have an "l" or "c" suffix.
+    """
+    circ_count, lin_count = int(0), int(0)
+
+    with open(fastalinear, 'a') as fhfl, open(fastacircular, 'a') as fhfc:
+        with open(loglinear, 'a') as fhll, open(logcircular, 'a') as fhlc:
+            for rec in SeqIO.parse(fasta, "fasta"):
+                if rec.id.endswith('l'):
+                    lin_count += 1
+                    fhfl.write(rec.format("fasta"))
+                    fhll.write("{}\t{}\n".format(rec.id, len(rec.seq)))
+                elif rec.id.endswith('c'):
+                    print("circular: {}\n\tlength: {}\n".format(rec.id, len(rec.seq) ))
+                    circ_count += 1
+                    fhfc.write(rec.format("fasta"))
+                    fhlc.write("{}\t{}\n".format(rec.id, len(rec.seq)))
+
+    #catch no-circulars by adding one dummy seq
+    if os.stat(fastacircular).st_size == 0:
+        with open(fastacircular, 'a') as fh:
+            fh.write(">dummyseq\nATCGATCGATCGATCGATCGATCGATCGATCGATCGATCG\n")
+        with open(logcircular, 'a') as fh:
+            fh.write("{}\t{}\n".format("NA", "0"))
+
+    print("Circular contigs: {:,}".format(circ_count))
+    print("Linear contigs: {:,}".format(lin_count))
+
+def parse_hicanu(fasta, fastalinear, fastacircular, loglinear, logcircular):
+    """
+    hicanu contig descriptions will have an "suggestCircular=yes" or "suggestCircular=no".
+    """
+    circ_count, lin_count = int(0), int(0)
+
+    with open(fastalinear, 'a') as fhfl, open(fastacircular, 'a') as fhfc:
+        with open(loglinear, 'a') as fhll, open(logcircular, 'a') as fhlc:
+            for rec in SeqIO.parse(fasta, "fasta"):
+                if "suggestCircular=yes" in rec.description:
+                    circ_count += 1
+                    fhfc.write(rec.format("fasta"))
+                    fhlc.write("{}\t{}\n".format(rec.id, len(rec.seq)))
+                elif "suggestCircular=no" in rec.description:
+                    lin_count += 1
+                    fhfl.write(rec.format("fasta"))
+                    fhll.write("{}\t{}\n".format(rec.id, len(rec.seq)))
+
+    #catch no-circulars by adding one dummy seq
+    if os.stat(fastacircular).st_size == 0:
+        with open(fastacircular, 'a') as fh:
+            fh.write(">dummyseq\nATCGATCGATCGATCGATCGATCGATCGATCGATCGATCG\n")
+        with open(logcircular, 'a') as fh:
+            fh.write("{}\t{}\n".format("NA", "0"))
+
+    print("Circular contigs: {:,}".format(circ_count))
+    print("Linear contigs: {:,}".format(lin_count))
+
+def parse_metaflye(fasta, metaflye_info, fastalinear, fastacircular, loglinear, logcircular):
+    """
+    metaflye fasta contains no information.
+    This is contained in the SAMPLE-assembly_info.txt file.
+    """
+    df = pd.read_csv(metaflye_info, sep='\t')
+    # this file may have changed symbols for yes, possibilities include a Y or +
+    circular_contigs = list(df[df['circ.'].isin(['Y', '+'])]["#seq_name"])
+
+    circ_count, lin_count = int(0), int(0)
+
+    with open(fastalinear, 'a') as fhfl, open(fastacircular, 'a') as fhfc:
+        with open(loglinear, 'a') as fhll, open(logcircular, 'a') as fhlc:
+            for rec in SeqIO.parse(fasta, "fasta"):
+                if rec.id in circular_contigs:
+                    circ_count += 1
+                    fhfc.write(rec.format("fasta"))
+                    fhlc.write("{}\t{}\n".format(rec.id, len(rec.seq)))
+                else:
+                    lin_count += 1
+                    fhfl.write(rec.format("fasta"))
+                    fhll.write("{}\t{}\n".format(rec.id, len(rec.seq)))
+
+    #catch no-circulars by adding one dummy seq
+    if os.stat(fastacircular).st_size == 0:
+        with open(fastacircular, 'a') as fh:
+            fh.write(">dummyseq\nATCGATCGATCGATCGATCGATCGATCGATCGATCGATCG\n")
+        with open(logcircular, 'a') as fh:
+            fh.write("{}\t{}\n".format("NA", "0"))
+            
+    print("Circular contigs: {:,}".format(circ_count))
+    print("Linear contigs: {:,}".format(lin_count))
+
+def main():
+    args = get_args()
+    write_headers(args.loglinear)
+    write_headers(args.logcircular)
+    print("Selected assembler: {}\n".format(args.assembler))
+    if args.assembler == "hifiasm-meta":
+        parse_hifiasm(args.fasta, args.fastalinear, args.fastacircular, args.loglinear, args.logcircular)
+    elif args.assembler == "hicanu":
+        parse_hicanu(args.fasta, args.fastalinear, args.fastacircular, args.loglinear, args.logcircular)
+    elif args.assembler == "metaflye":
+        if not os.path.isfile(args.metaflye_info):
+            raise IOError("Could not locate assembly info file: {}".format(args.metaflye_info))
+        else:
+            parse_metaflye(args.fasta, args.metaflye_info, args.fastalinear, args.fastacircular, args.loglinear, args.logcircular)
+
+if __name__ == '__main__':
+    main()
+
+"""
+Finding circular contigs...
+
+hifiasm-meta:
+>s4.ctg000732l
+>s11.ctg000015c
+
+hicanu:
+>tig00000001 len=5293670 reads=39793 class=contig suggestRepeat=no suggestBubble=no suggestCircular=no
+>tig00000481 len=17533 reads=9 class=contig suggestRepeat=no suggestBubble=no suggestCircular=yes
+
+metaFlye:
+only available in SAMPLE-assembly_info.txt:
+
+#seq_name	length	cov.	circ.	repeat	mult.	alt_group	graph_path
+contig_11909	3733704	14	Y	N	1	*	11909
+contig_11404	3650108	58	N	N	2	*	-11400,11404,-11400
+"""


### PR DESCRIPTION
Pull out circular and linear contigs, bin linear contigs with MetaBat2. Perform binning on full contig set as well. Treat all circular contigs as a bin. Merge the bins using DAS Tool. Provides an increase in total bins recovered, as well as prevents circular and nearly complete contigs from being mis-binned.