### PR TITLE
Bug fixes

### DIFF
--- a/Taxonomic-Profiling-Sourmash/Snakefile-sourmash
+++ b/Taxonomic-Profiling-Sourmash/Snakefile-sourmash
@@ -36,7 +36,7 @@ onerror:
 rule all:
     input:
         expand(os.path.join(out_dir, '2-gather', '{sample}.k{ks}.gather.with-lineages.csv'),sample=SAMPLES, ks=ksize),
-        expand(os.path.join(out_dir, '3-taxprofile', '{sample}.k{ks}.gather.kreport.txt'), sample=SAMPLES, ks=ksize),
+        expand(os.path.join(out_dir, '3-taxprofile', '{sample}.k{ks}.gather.genbank.kreport.txt'), sample=SAMPLES, ks=ksize),
 
 
 rule sourmash_sketch_dna:
@@ -91,9 +91,9 @@ rule tax_metagenome:
         gather = os.path.join(out_dir, '2-gather', '{sample}.k{ksize}.gather.csv'),
         lineages = sourmash_params['database_lineage_files'],
     output:
-        os.path.join(out_dir, '3-taxprofile', '{sample}.k{ksize}.gather.krona.tsv'),
-        os.path.join(out_dir, '2-taxprofile', '{sample}.k{ksize}.gather.summarized.csv'),
-        os.path.join(out_dir, '3-taxprofile', '{sample}.k{ksize}.gather.kreport.txt'),
+        os.path.join(out_dir, '3-taxprofile', '{sample}.k{ksize}.gather.genbank.krona.tsv'),
+        os.path.join(out_dir, '3-taxprofile', '{sample}.k{ksize}.gather.genbank.summarized.csv'),
+        os.path.join(out_dir, '3-taxprofile', '{sample}.k{ksize}.gather.genbank.kreport.txt'),
     threads: 1
     resources:
         mem_mb=lambda wildcards, attempt: attempt *3000,


### PR DESCRIPTION
Outputs listed in rule `tax_metagenome` were missing the `genbank` piece, one folder was numbered incorrectly. This caused the workflow to crash when the expected outputs were not found.

Also fixed output filename structure in rule `all`, for same reasons listed above.

Sidenote - Benchmarking showed values for `max_rss` ranged between 37-49 Gb for K51 and 51-52 Gb for K31.