### PR TITLE
Fix path bug:

### DIFF
--- a/HiFi-MAG-Pipeline/Snakefile-hifimags.smk
+++ b/HiFi-MAG-Pipeline/Snakefile-hifimags.smk
@@ -348,7 +348,7 @@ rule CopyDAStoolBins:
     log:
         os.path.join(CWD, "logs", "{sample}.CopyDAStoolBins.log")
     shell:
-        "cp {input.binsdir}*.fa {input.copydir} 2> {log} && touch {output}"
+        "cp {input.binsdir}/*.fa {input.copydir} 2> {log} && touch {output}"
 
 ##################################################################################################
 # CheckM2 analysis and checkpoint, fork to GTDB-Tk & summary (if bins found) or end analysis (no bins found)


### PR DESCRIPTION
Add a '/' to allow proper wildcard expansion.

Currently gives `No such file or directory` error: 
```
cp: cannot stat '/hifiasm/pb-metagenomics-tools/HiFi-MAG-Pipeline/4-DAStool/Sample/Sample_DASTool_bins*.fa': No such file or directory
```