### PR TITLE
Fix DAS_Tool bug

### DIFF
--- a/HiFi-MAG-Pipeline/Snakefile-hifimags.smk
+++ b/HiFi-MAG-Pipeline/Snakefile-hifimags.smk
@@ -261,7 +261,7 @@ rule DASinputMetabat2:
     log:
         os.path.join(CWD, "logs", "{sample}.DASinputMetabat2.log")
     shell:
-        "Fasta_to_Scaffolds2Bin.sh -i {input} -e fa 1> {output} 2> {log}"
+        "Fasta_to_Contig2Bin.sh -i {input} -e fa 1> {output} 2> {log}"
 
 
 ##################################################################################################
@@ -303,7 +303,7 @@ rule DASinputSemiBin2:
     log:
         os.path.join(CWD, "logs", "{sample}.DASinputSemiBin2.log")
     shell:
-        "Fasta_to_Scaffolds2Bin.sh -i {params.indir} -e fa 1> {output} 2> {log}"
+        "Fasta_to_Contig2Bin.sh -i {params.indir} -e fa 1> {output} 2> {log}"
 
 ##################################################################################################
 # Run DAS_Tool
@@ -331,7 +331,7 @@ rule DAStoolAnalysis:
     shell:
         "DAS_Tool -i {input.metabat},{input.semibin} -c {input.contigs} "
         "-l metabat2,semibin2 -o {params.outlabel} --search_engine {params.search} "
-        "--write_bins 1 -t {threads} --score_threshold {params.thresh} --debug "
+        "--write_bins -t {threads} --score_threshold {params.thresh} --debug "
         "&> {log} && touch {output.complete}"
 
 rule CopyDAStoolBins:

--- a/HiFi-MAG-Pipeline/envs/dastool.yml
+++ b/HiFi-MAG-Pipeline/envs/dastool.yml
@@ -4,5 +4,5 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - das_tool = 1.1
+  - das_tool == 1.1.6
 


### PR DESCRIPTION
Update to **HiFi-MAG-Pipeline**:

Depending on version of DAS_Tool, the name of the helper script used to generate input files will change.

Digging in to the current script shows the prior name still listed, adding to confusion: https://github.com/cmks/DAS_Tool/blob/master/src/Fasta_to_Contig2Bin.sh

<= v1.1.3 : `Fasta_to_Scaffolds2Bin.sh`
> v1.1.3 : `Fasta_to_Contig2Bin.sh`

Snakemake was set to run with name from <= v1.1.3, causing errors if newer version was installed through conda.

This bug fix now pins the version of DAS_Tool to 1.1.6 and uses the `Fasta_to_Contig2Bin.sh` name in the workflow. This should eliminate errors stemming from incompatible version and script name.