### PR TITLE
bug fix for large refs

### DIFF
--- a/HiFi-MAG-Pipeline/Snakefile-hifimags.smk
+++ b/HiFi-MAG-Pipeline/Snakefile-hifimags.smk
@@ -191,7 +191,7 @@ rule MinimapToBam:
     benchmark: 
         os.path.join(CWD, "benchmarks", "{sample}.MinimapToBam.tsv")
     shell:
-        "minimap2 -a --sam-hit-only --secondary=no -t {threads} --split-prefix temp " 
+        "minimap2 -a --sam-hit-only --secondary=no -t {threads} --split-prefix temp_{wildcards.sample} " 
         "{input.index} {input.reads} 2> {log} | samtools sort -@ {threads} -o {output}"
         
 rule IndexBam:


### PR DESCRIPTION
Given a reference longer than 4Gb, minimap2 is unable to see all the sequences and thus can't produce a correct SAM header. This throws an error in the `MinimapToBam` rule with the sorting step. This fix avoids the issue by splitting this rule into two new rules: `MinimapIndex` and `MinimapToBam`. These rules index the reference prior to alignment and run minimap2 with the `--split-prefix` option, respectively.