### PR TITLE
HiFi-MAG-Pipeline: Upgrade minimap2 to 2.26

### DIFF
--- a/HiFi-MAG-Pipeline/envs/samtools.yml
+++ b/HiFi-MAG-Pipeline/envs/samtools.yml
@@ -5,4 +5,4 @@ channels:
   - defaults
 dependencies:
   - samtools == 1.10
-  - minimap2 == 2.17
+  - minimap2 == 2.26


### PR DESCRIPTION
I also ran into #67. Upgrading to 2.26 resolved the issue for me.

- Upgrade minimap2 to `2.26` for `map-hifi` support.