### PR TITLE
Filter superbins

### DIFF
--- a/HiFi-MAG-Pipeline/Snakefile-hifimags.smk
+++ b/HiFi-MAG-Pipeline/Snakefile-hifimags.smk
@@ -301,11 +301,30 @@ rule SemiBin2Analysis:
         "SemiBin single_easy_bin -i {input.contigs} -b {input.bam} -o {output.outdir} --self-supervised "
         "--sequencing-type=long_reads --compression=none -t {threads} --tag-output semibin2 {params.modelflag} "
         "--verbose --tmpdir={params.tmp} &> {log}"
-#--environment=global
+
+rule FilterSuperBins:
+    input:
+        os.path.join(CWD, "3-semibin2", "{sample}", "bins_info.tsv")
+    output:
+        outdir = directory(os.path.join(CWD, "3-semibin2", "{sample}", "superbins")),
+        outfile = os.path.join(CWD, "3-semibin2", "{sample}", "{sample}.superbins.txt")
+    conda:
+        "envs/python.yml"
+    params:
+        indir = os.path.join(CWD, "3-semibin2", "{sample}", "output_bins", "")
+    threads:
+        1
+    log:
+        os.path.join(CWD, "logs", "{sample}.FilterSuperBins.log")
+    benchmark:
+        os.path.join(CWD, "benchmarks", "{sample}.FilterSuperBins.tsv")
+    shell:
+        "python scripts/Filter-Semibin.py -i {params.indir} -o {output.outdir} -f {output.outfile} "
+        " &> {log}"
 
 rule DASinputSemiBin2:
     input:
-        os.path.join(CWD, "3-semibin2", "{sample}", "")
+        os.path.join(CWD, "3-semibin2", "{sample}", "{sample}.superbins.txt")
     output:
         os.path.join(CWD, "4-DAStool", "{sample}.semibin2.tsv")
     conda:

--- a/HiFi-MAG-Pipeline/scripts/Filter-Semibin.py
+++ b/HiFi-MAG-Pipeline/scripts/Filter-Semibin.py
@@ -1,0 +1,54 @@
+import argparse
+import os
+import shutil
+
+def get_args():
+    """
+    Get arguments from command line with argparse.
+    """
+    parser = argparse.ArgumentParser(
+        prog='Filter-SemiBin.py',
+        description="""Identify any superbins (>100Mb) from semibin2 and move to a separate directory.""")
+    parser.add_argument("-i", "--in_dir",
+                        required=True,
+                        help="The full path to the semibin2 bins directory.")
+    parser.add_argument("-o", "--out_dir",
+                        required=True,
+                        help="The full path to the output directory.")
+    parser.add_argument("-f", "--outfile",
+                        required=True,
+                        help="Name of output file to write.")
+
+    return parser.parse_args()
+
+def make_dir(out_dir):
+    os.makedirs(out_dir, exist_ok=True)
+
+def filter_bin_files(in_dir, out_dir):
+    mv_count = 0
+    print("filter_bin_files: getting files")
+    os.chdir(in_dir)
+    fasta_files = [f for f in os.listdir('.') if f.endswith((".fa", ".fasta"))]
+    print("filter_bin_files: removing large (>100Mb) files")
+    for f in fasta_files:
+        if os.path.getsize(f) >= 100000000:
+            print("\tMoved file {}: {:,} bytes".format(f, os.path.getsize(f)))
+            mv_count += 1
+            shutil.move(f, os.path.join(out_dir, f))
+    print("filter_bin_files: Identified {} super bins".format(mv_count))
+
+    return mv_count
+
+def write_outfile(outfile, mv_count, out_dir):
+    print("write_outfile: Writing output file.")
+    with open(outfile, 'w') as fh:
+        fh.write("Identified {} super bins\nFile(s) located in: {}".format(mv_count, out_dir))
+
+def main():
+    args = get_args()
+    make_dir(args.out_dir)
+    mv_count = filter_bin_files(args.in_dir, args.out_dir)
+    write_outfile(args.outfile, mv_count, args.out_dir)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Identifies superbins output from SemiBin2, which are >100 Mb in size. Including very large superbins (~1GB) will cause crashes in DAS_Tool. This new identification step will move all superbins to a superbin folder in the SemiBin2 output directory. These bins can be inspected to determine their contents, which can sometimes contain interesting eukaryotic genomes.