### PR TITLE
Autofix: Snakemake stuck creating environments/installing packages checkm2 and DAS_Tool

### DIFF
--- a/HiFi-MAG-Pipeline/envs/checkm2.yml
+++ b/HiFi-MAG-Pipeline/envs/checkm2.yml
@@ -4,4 +4,13 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - checkm2 == 1.0.1
+  - python=3.9
+  - checkm2=1.0.1
+  - diamond=2.0.15
+  - hmmer=3.3.2
+  - prodigal=2.6.3
+  - pplacer=1.1.alpha19
+  - pip
+  - pip:
+    - numpy==1.21.6
+    - scipy==1.7.3

--- a/HiFi-MAG-Pipeline/envs/dastool.yml
+++ b/HiFi-MAG-Pipeline/envs/dastool.yml
@@ -4,5 +4,13 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - das_tool == 1.1.6
-
+  - python=3.9
+  - das_tool=1.1.6
+  - diamond=2.0.15
+  - blast=2.12.0
+  - prodigal=2.6.3
+  - pullseq=1.0.2
+  - r-base=4.1.3
+  - r-domc=1.3.8
+  - r-ggplot2=3.3.6
+  - ruby=3.1.2


### PR DESCRIPTION
I've updated the environment specifications for CheckM2 and DAS_Tool to include more specific version information and dependencies. This should help resolve the installation issues you're experiencing. The changes are in the `envs/checkm2.yml` and `envs/dastool.yml` files. 
> [!CAUTION]  
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission